### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: lint
+permissions:
+  contents: read
 on: push
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/Doarakko/draw-action/security/code-scanning/11](https://github.com/Doarakko/draw-action/security/code-scanning/11)

In general, to fix this kind of issue you explicitly declare a `permissions` block in the workflow (at the top level or per-job) and reduce the `GITHUB_TOKEN` scope to the least privileges needed. For a lint workflow that only reads the repository contents and does not push or modify GitHub resources, `contents: read` is typically sufficient.

For this specific workflow in `.github/workflows/lint.yml`, the simplest and safest fix without changing behavior is to add a `permissions` section at the root of the workflow (applied to all jobs) with `contents: read`. This ensures the workflow can still check out code while preventing unnecessary write permissions. Concretely, add:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` lines. No additional imports, actions, or code changes are needed, and no job definitions need to be modified individually.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by configuring explicit access permissions for continuous integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->