### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
 name: Draw Yu-Gi-Oh! Card
+permissions:
+  contents: read
+  issues: write
 on:
   issue_comment:
     types: [created, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/Doarakko/draw-action/security/code-scanning/5](https://github.com/Doarakko/draw-action/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scopes needed. This can be defined at the workflow root (applies to all jobs) or inside the specific job (applies only to that job). Here, there is only one job (`draw`), so either level works; using a root‑level block is clean and documents the workflow’s needs.

The best minimal, non‑breaking change is to add a `permissions` block at the top level, just after `name:` (or after `on:`), granting read access to contents and write access to issues (so the action can comment/update issues if needed). That keeps current functionality while constraining the token. Concretely, edit `.github/workflows/main.yml` to add:

```yaml
permissions:
  contents: read
  issues: write
```

at the root level with indentation aligned to `name:` and `on:`. No imports or additional definitions are needed, since this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to explicitly define permissions for repository contents access and issue management operations, enhancing security controls for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->